### PR TITLE
(hopefully) Fixed performance problem

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
         <dependency>
             <groupId>intellimate.izou</groupId>
             <artifactId>Izou</artifactId>
-            <version>1.0-SNAPSHOT</version>
+            <version>1.0.1-SNAPSHOT</version>
         </dependency>
         <dependency>
             <groupId>leanderk.izou.tts</groupId>
@@ -37,12 +37,18 @@
         <dependency>
             <groupId>com.yahoofinance-api</groupId>
             <artifactId>yahoofinance</artifactId>
-            <version>1.0.1</version>
+            <version>1.1.0</version>
         </dependency>
         <dependency>
             <groupId>jundl77.izou.izousound</groupId>
             <artifactId>izousound</artifactId>
             <version>1.0</version>
+        </dependency>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.11</version>
+            <scope>test</scope>
         </dependency>
     </dependencies>
 

--- a/src/Test/java/jundl77/izou/izoustocks/StocksContentGeneratorTest.java
+++ b/src/Test/java/jundl77/izou/izoustocks/StocksContentGeneratorTest.java
@@ -1,0 +1,50 @@
+package jundl77.izou.izoustocks;
+
+import intellimate.izou.events.Event;
+import intellimate.izou.main.Main;
+import intellimate.izou.properties.PropertiesContainer;
+import intellimate.izou.system.Context;
+import org.junit.Test;
+
+import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
+import java.util.Arrays;
+import java.util.Optional;
+
+public class StocksContentGeneratorTest {
+    @Test
+    public void testAnnounceResources() {
+        StocksContentGenerator stocksContentGenerator = new StocksContentGenerator(new MockStocksContext());
+        LocalTime before = LocalTime.now();
+        stocksContentGenerator.provideResource(stocksContentGenerator.announceResources(), Optional.<Event>empty());
+        //without List: 3, 4, 3, 4 Seconds
+        //without < 0
+        System.out.println(ChronoUnit.SECONDS.between(before, LocalTime.now()));
+    }
+    
+    private class MockStocksContext extends Context {
+        public MockStocksContext() {
+            super(new StocksAddOn(), new Main(Arrays.asList(), true), "DEBUG");
+            Context context = this;
+            properties = new Properties() {
+                @Override
+                public PropertiesContainer getPropertiesContainer() {
+                    return new PropertiesContainer(context) {
+                        @Override
+                        public java.util.Properties getProperties() {
+                            java.util.Properties properties1 = new java.util.Properties();
+                            properties1.setProperty("Google", "GOOG");
+                            properties1.setProperty("Apple", "AAPL");
+                            properties1.setProperty("Euro_to_dollar", "EURUSD=X");
+                            properties1.setProperty("Intel", "INTC");
+                            properties1.setProperty("Dow Jones Industrial Average", "DJI");
+                            properties1.setProperty("BMW", "BMW.DE");
+                            properties1.setProperty("Facebook", "FB");
+                            return properties1;
+                        }
+                    };
+                }
+            };
+        }
+    }
+}

--- a/src/main/java/Debug.java
+++ b/src/main/java/Debug.java
@@ -11,6 +11,6 @@ public class Debug {
     public static void main(String[] args) {
         LinkedList<AddOn> addOns = new LinkedList<>();
         addOns.add(new StocksAddOn());
-        Main main = new Main(addOns, true);
+        Main main = new Main(addOns);
     }
 }

--- a/src/main/java/jundl77/izou/izoustocks/StocksContentGenerator.java
+++ b/src/main/java/jundl77/izou/izoustocks/StocksContentGenerator.java
@@ -45,26 +45,22 @@ public class StocksContentGenerator extends ContentGenerator {
         Properties properties = getContext().properties.getPropertiesContainer().getProperties();
         StocksFetchedData fetchedData = new StocksFetchedData(getContext().properties.getPropertiesContainer().
                 getProperties().getProperty("audioFileName"));
-
-        for (Object keyObj : properties.keySet()) {
-            String stockName = (String) keyObj;
-
+        List<String> tickers = new ArrayList<>();
+        for (String stockName : properties.stringPropertyNames()) {
             if (stockName.equals("audioFileName")) {
                 continue;
             }
-
-            stockName = stockName.replace("_", " ");
-            String ticker = (String) properties.get(keyObj);
-            Stock stock = YahooFinance.get(ticker);
-
-            if (stock != null) {
-                fetchedData.addStock(stockName, stock);
-            } else {
-                getContext().logger.getLogger().debug("Request to get " + ticker + " from Yahoo Finance failed");
-            }
-
+            String ticker = (String) properties.get(stockName);
+            tickers.add(ticker);
         }
-
+        Map<String, Stock> stocks = YahooFinance.get(tickers.toArray(new String[tickers.size()]));
+        for (Map.Entry<String, Stock> entry : stocks.entrySet()) {
+            if (entry.getValue() != null) {
+                fetchedData.addStock(entry.getKey().replace("_", " "), entry.getValue());
+            } else {
+                getContext().logger.getLogger().debug("Request to get " + entry.getKey() + " from Yahoo Finance failed");
+            }
+        }
         return fetchedData;
     }
 


### PR DESCRIPTION
Assuming you used this https://github.com/sstrickx/yahoofinance-api library there is a new version available.

Instead of request every stock individually, a batch-request is now performed.

Running some simple tests showed significant performance improvements.

without batch request: 3, 4, 3, 4 Seconds elapsed calling the provideResource-method.
with batch request call i performed was under one second.

I haven't tested it on the rpi yet, maybe you can measure the performance gain and determine if we have to do some further optimizations.